### PR TITLE
Honour OnStateName/OffStateName on GSM/ULTRA inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Older or non-Wi-Fi motors reached through a Centurion cellular module (e.g. **G-
 
 - **Open/close** works as a single-button trigger (a momentary pulse), just like the physical remote.
 - **Auxiliary outputs** — any additional configured outputs (pedestrian, lock, garage, courtesy light, ...) surface as separate entities: momentary outputs as **buttons**, two-state outputs as **switches**, and status-feedback inputs as **binary sensors** — matching the buttons you see in the app.
+- **Input state labels** follow the on/off labels configured in the app, including inverted labels.
+- The `raw_state` attribute exposes the electrical level for automations that need it.
 - **Live open/closed position** is only available if the module has a **status-feedback input wired**. When present, the cover greys correctly; when not (most installs are trigger-only), the cover uses "assumed state" and both buttons stay pressable.
 - **Diagnostics** (as separate sensors): supply voltage, signal strength, antenna, firmware, connection status, network type (2G/3G/4G), device number, and — on prepaid SIMs, after pressing **Refresh airtime** — call/SMS token counts.
 

--- a/custom_components/centsys_remote/api/models.py
+++ b/custom_components/centsys_remote/api/models.py
@@ -216,6 +216,32 @@ def gsm_io_is_on(state_id: int | None) -> bool | None:
     return state_id % 2 == 0
 
 
+_GSM_IO_TRUE_LABELS = {"on", "open", "active", "true", "1", "running", "aan"}
+_GSM_IO_FALSE_LABELS = {"off", "closed", "inactive", "false", "0", "stopped", "af"}
+
+
+def gsm_io_label_state(
+    raw: bool | None, on_label: str, off_label: str
+) -> tuple[str | None, bool | None]:
+    """Map a raw IO state to the label shown by the app and its meaning.
+
+    This handles inverted labels such as a pump with ``OnStateName="off"`` and
+    ``OffStateName="on"`` because the app renders the label, so HA must agree
+    with the app rather than report only the electrical level.
+    """
+    if raw is None:
+        return None, None
+    label = on_label if raw else off_label
+    normalized = label.strip().casefold()
+    if not normalized:
+        return label, raw
+    if normalized in _GSM_IO_TRUE_LABELS:
+        return label, True
+    if normalized in _GSM_IO_FALSE_LABELS:
+        return label, False
+    return label, raw
+
+
 @dataclass
 class GsmStatus:
     """Live IO states for a legacy GSM/ULTRA operator.

--- a/custom_components/centsys_remote/binary_sensor.py
+++ b/custom_components/centsys_remote/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .api.models import gsm_io_label_state
 from .const import DOMAIN
 from .coordinator import CentsysCoordinator
 from .entity import CentsysEntity, CentsysGsmIoEntity, async_setup_dynamic_entities
@@ -225,4 +226,13 @@ class CentsysGsmIoBinarySensor(CentsysGsmIoEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         status = self._status
-        return status.is_on(self._io_number) if status else None
+        raw = status.is_on(self._io_number) if status else None
+        return gsm_io_label_state(raw, self._io.on_state_name, self._io.off_state_name)[1]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        status = self._status
+        raw = status.is_on(self._io_number) if status else None
+        label, _ = gsm_io_label_state(raw, self._io.on_state_name, self._io.off_state_name)
+        attributes = {"state_label": label, "raw_state": raw}
+        return {key: value for key, value in attributes.items() if value is not None}

--- a/custom_components/centsys_remote/entity.py
+++ b/custom_components/centsys_remote/entity.py
@@ -207,6 +207,7 @@ class CentsysGsmIoEntity(CentsysGsmEntity):
 
     def __init__(self, coordinator: CentsysCoordinator, key: str, io) -> None:
         super().__init__(coordinator, key)
+        self._io = io
         self._io_number = io.io_number
         label, icon = gsm_io_presentation(io.io_name, io.io_number)
         self._attr_name = label

--- a/tests/test_gsm_io_states.py
+++ b/tests/test_gsm_io_states.py
@@ -88,6 +88,30 @@ def test_is_on_offline_is_unknown() -> None:
     assert status.is_on(1) is None
 
 
+def test_label_state_inverted_labels_flip_result() -> None:
+    assert models.gsm_io_label_state(True, "off", "on") == ("off", False)
+    assert models.gsm_io_label_state(False, "off", "on") == ("on", True)
+
+
+def test_label_state_normal_labels_preserve_raw() -> None:
+    assert models.gsm_io_label_state(True, "on", "off") == ("on", True)
+    assert models.gsm_io_label_state(False, "on", "off") == ("off", False)
+
+
+def test_label_state_unrecognised_labels_fall_back_to_raw() -> None:
+    assert models.gsm_io_label_state(True, "PULSED", "Gate Open") == ("PULSED", True)
+    assert models.gsm_io_label_state(False, "PULSED", "Gate Open") == ("Gate Open", False)
+
+
+def test_label_state_empty_labels_fall_back_to_raw() -> None:
+    assert models.gsm_io_label_state(True, "", "") == ("", True)
+    assert models.gsm_io_label_state(False, "", "") == ("", False)
+
+
+def test_label_state_unknown_raw_is_unknown() -> None:
+    assert models.gsm_io_label_state(None, "on", "off") == (None, None)
+
+
 def test_missing_entries_keep_alignment() -> None:
     # A malformed/empty entry must not shift the IOs that follow it.
     root = {"IOList": [{}, {"IOStateID": 89}]}


### PR DESCRIPTION
`IOConfigs` carries `OnStateName` / `OffStateName`: the labels the app shows for an input's two raw states, and users can configure them inverted. Real case from my account, a pump controller with IO 1 configured as `{"IOName":"pomp","IODirection":1,"OnStateName":"off","OffStateName":"on"}`. The integration already parses those fields into `GsmIo` but nothing read them, so the binary sensor reported the raw level and HA showed the opposite of the app.

This derives `is_on` from the configured label when it is recognisably boolean (on/off, open/closed, active/inactive, true/false, 1/0, running/stopped, plus Afrikaans aan/af), and falls back to the raw level for anything else ("PULSED", custom text, empty). Two attributes are added: `state_label` (what the app displays) and `raw_state` (the electrical level, for automations that want it).

Tests added in the existing synthetic-package style in `tests/test_gsm_io_states.py` (47 -> 52). README note under GSM/ULTRA operators.

The pump IOConfig above is copied from a real account; I have not yet run this branch on a live install, so treat the label-to-boolean mapping as proposed and tell me if you'd rather it were opt-in.
